### PR TITLE
ci: fix issues in "slither-analyze" job in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
 
   slither-analyze:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
           fail-on: none # Required to avoid failing the CI run regardless of findings.
           sarif: results.sarif
           slither-args: --filter-paths "./lib|./test" --exclude naming-convention
+          target: contracts/
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           fail-on: none # Required to avoid failing the CI run regardless of findings.
           sarif: results.sarif
-          slither-args: --filter-paths "./lib|./test" --exclude naming-convention
+          slither-args: --exclude naming-convention
           target: src/
 
       - name: Upload SARIF file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           fail-on: none # Required to avoid failing the CI run regardless of findings.
           sarif: results.sarif
           slither-args: --filter-paths "./lib|./test" --exclude naming-convention
-          target: contracts/
+          target: src/
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v2


### PR DESCRIPTION
I've been trying to use the "slither-analyze" job for [hifi-finance/foundry-template](https://github.com/hifi-finance/foundry-template), and I noticed the issue with the CI failing due to not providing the Slither command with a target.
I was able to fix this in hifi-finance/foundry-template as shown [here](https://github.com/hifi-finance/foundry-template/blob/c70f3f7668d7c2ff5d609567699e7382ba8f3bef/.github/workflows/ci.yml#L67).