### PR TITLE
chore: explicitly specify slither permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
   slither-analyze:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Closes https://github.com/ScopeLift/foundry-template/issues/17

The slither-action README [shows](https://github.com/crytic/slither-action#example-workflow-hardhat-and-sarif) this permission being set and we previously left it out since we thought it wasn't needed, but it seems that's not the case 