### PR TITLE
Configure coverage independently + updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    env:
+      FOUNDRY_PROFILE: coverage
     steps:
       - uses: actions/checkout@v3
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
   evm_version = "paris"
   optimizer = true
   optimizer_runs = 10_000_000
-  solc_version = "0.8.26"
+  solc_version = "0.8.28"
   verbosity = 3
 
 [profile.ci]

--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,10 @@
   fuzz = { runs = 5000 }
   invariant = { runs = 1000 }
 
+[profile.coverage]
+  fuzz = { runs = 100 }
+  invariant = { runs = 0 }
+
 [profile.lite]
   fuzz = { runs = 50 }
   invariant = { runs = 10 }

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 // slither-disable-start reentrancy-benign
 
-pragma solidity 0.8.26;
+pragma solidity 0.8.28;
 
 import {Script} from "forge-std/Script.sol";
 import {Counter} from "src/Counter.sol";

--- a/src/Counter.sol
+++ b/src/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.26;
+pragma solidity 0.8.28;
 
 contract Counter {
   uint256 public number;

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.26;
+pragma solidity 0.8.28;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {Deploy} from "script/Deploy.s.sol";


### PR DESCRIPTION
* The CI job on coverage should only run unit tests, not invariant tests, and it does not need many fuzz runs of these tests just to ensure the code is covered.
* Bump to solc v0.8.28 and forge-std v1.9.6