### PR TITLE
Bump versions of evm, solc, and forge-std

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,8 +1,8 @@
 [profile.default]
-  evm_version = "paris"
+  evm_version = "cancun"
   optimizer = true
   optimizer_runs = 10_000_000
-  solc_version = "0.8.28"
+  solc_version = "0.8.29"
   verbosity = 3
 
 [profile.ci]

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 // slither-disable-start reentrancy-benign
 
-pragma solidity 0.8.28;
+pragma solidity 0.8.29;
 
 import {Script} from "forge-std/Script.sol";
 import {Counter} from "src/Counter.sol";

--- a/src/Counter.sol
+++ b/src/Counter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.28;
+pragma solidity 0.8.29;
 
 contract Counter {
   uint256 public number;

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.28;
+pragma solidity 0.8.29;
 
 import {Test, console2} from "forge-std/Test.sol";
 import {Deploy} from "script/Deploy.s.sol";


### PR DESCRIPTION
* Bump the EVM target to cancun
* Bump the version of solc to 0.8.29
* Bump forge-std to v1.9.7